### PR TITLE
Added option to specify a callback for slide change

### DIFF
--- a/src/simpleslider.js
+++ b/src/simpleslider.js
@@ -230,6 +230,7 @@
     this.endVal = parseInt(getdef(options.endValue, width + this.unit), 10);
     this.autoPlay = getdef(parseStringToBoolean(options.autoPlay), true);
     this.ease = getdef(options.ease, SimpleSlider.defaultEase);
+    this.onChange = getdef(options.onChange , null);
 
     this.init();
   };
@@ -382,6 +383,10 @@
     this.insert(newIndex);
 
     this.actualIndex = newIndex;
+
+    if (this.onChange !== null) {
+      this.onChange();
+    }
 
   };
 


### PR DESCRIPTION
Wrote this option so that I'll be able to write a function when a change is initiated on the slide. 

ex: 
The slider had next and previous buttons controlling the slide as well as links the changes the slide. The links has an active state that needed to toggle through if the next or previous buttons were clicked.  With this option I was able to tie them together. Very useful for sliders that have indicators that tell you what slide you are on.